### PR TITLE
error catch when employee exists

### DIFF
--- a/backend/src/auth/strategies/local.strategy.ts
+++ b/backend/src/auth/strategies/local.strategy.ts
@@ -19,7 +19,7 @@ export class LocalStrategy extends PassportStrategy(Strategy){
 async validate(email:string,password:string):Promise<any>
 {
     const employeeAuth= await this.authService.validateEmployee(email,password);
-    console.log('local-stragy'+employeeAuth);
+
     if(!employeeAuth)
     {
         

--- a/backend/src/employee/employee.controller.ts
+++ b/backend/src/employee/employee.controller.ts
@@ -12,7 +12,7 @@ export class EmployeeController {
   }
 
   @Post()
-  async createEmployee(@Body() newEmployee: Employee): Promise<Employee> {
+  async createEmployee(@Body() newEmployee: Employee): Promise<void> {
     return await this.employeeService.createEmployee(newEmployee);
   }
 }


### PR DESCRIPTION
If we try to create a employee that is already existed. The server was returning 501 internal server error which would cause the error log in the log. Wrap with try-catch block to specify the error. 